### PR TITLE
Require tracing macros from cljs

### DIFF
--- a/src/day8/re_frame/tracing.cljc
+++ b/src/day8/re_frame/tracing.cljc
@@ -2,7 +2,10 @@
   #?(:cljs (:require-macros
              [debux.dbgn :as dbgn]
              [debux.cs.macro-types :as mt]
-             [day8.re-frame.tracing]))
+             [day8.re-frame.tracing])
+     :clj (:require
+            [debux.dbgn :as dbgn]
+            [debux.cs.macro-types :as mt]))
   (:require [debux.common.util :as ut]
             [debux.common.macro-specs :as ms]
             [clojure.spec.alpha :as s]))

--- a/src/day8/re_frame/tracing.cljc
+++ b/src/day8/re_frame/tracing.cljc
@@ -1,7 +1,8 @@
 (ns day8.re-frame.tracing
   #?(:cljs (:require-macros
              [debux.dbgn :as dbgn]
-             [debux.cs.macro-types :as mt]))
+             [debux.cs.macro-types :as mt]
+             [day8.re-frame.tracing]))
   (:require [debux.common.util :as ut]
             [debux.common.macro-specs :as ms]
             [clojure.spec.alpha :as s]))

--- a/tracing-stubs/src/day8/re_frame/tracing.cljc
+++ b/tracing-stubs/src/day8/re_frame/tracing.cljc
@@ -1,4 +1,5 @@
-(ns day8.re-frame.tracing)
+(ns day8.re-frame.tracing
+  #?(:cljs (:require-macros [day8.re-frame.tracing])))
 
 (defmacro defn-traced
   "Traced defn, this variant compiles down to the standard defn, without tracing."


### PR DESCRIPTION
I'm writing a re-frame app with most of my code in cljc files. This means my ns forms have to include reader conditionals when requiring `day8.re-frame.tracing` which makes for some long lines. This PR allows you to use the [implicit refer sugar](https://clojurescript.org/guides/ns-forms#_implicit_sugar), like so:

```clj
(ns my.app
  (:require [day8.re-frame.tracing :refer [defn-traced fn-traced]]))

;; instead of something like:
(ns my.app
  (:require [day8.re-frame.tracing #?(:cljs :refer-macros :clj :refer) [defn-traced fn-traced]]))
```
